### PR TITLE
fix: handle missing links.download in Bitbucket Cloud file content re…

### DIFF
--- a/src/handlers/file-handlers.ts
+++ b/src/handlers/file-handlers.ts
@@ -219,14 +219,17 @@ export class FileHandlers {
         }
 
         // Follow the download link to get actual content
-        const downloadUrl = metadataResponse.links.download.href;
+        const downloadUrl = metadataResponse.links?.download?.href
+          ?? metadataResponse.links?.self?.href
+          ?? metaPath;
+        const isAbsoluteUrl = downloadUrl.startsWith('http');
         const downloadResponse = await this.apiClient.makeRequest<any>('get', downloadUrl, undefined, {
-          baseURL: '', // Use full URL
+          ...(isAbsoluteUrl ? { baseURL: '' } : {}),
           responseType: 'text',
           headers: { 'Accept': 'text/plain' }
         });
         
-        fileContent = downloadResponse;
+        fileContent = typeof downloadResponse === 'string' ? downloadResponse : JSON.stringify(downloadResponse);
       }
 
       // Apply line filtering if requested


### PR DESCRIPTION
…sponse

Bitbucket Cloud's /src/ endpoint does not always return links.download in the metadata response — it may only provide links.self or links.meta. This caused a TypeError: Cannot read properties of undefined (reading 'href') when attempting to fetch file content from Cloud repositories.

Changes:
- Add fallback chain for download URL: links.download → links.self → metaPath
- Conditionally set baseURL only when the resolved URL is absolute
- Safely handle non-string responses with typeof check and JSON.stringify