### PR TITLE
fix: add null-safety guards for reviewers, participants, and commit.parents

### DIFF
--- a/src/handlers/branch-handlers.ts
+++ b/src/handlers/branch-handlers.ts
@@ -286,11 +286,11 @@ export class BranchHandlers {
           destination_branch: pr.toRef.displayId,
           author: pr.author.user.displayName,
           created_on: new Date(pr.createdDate).toISOString(),
-          reviewers: pr.reviewers.map((r: any) => r.user.displayName),
+          reviewers: (pr.reviewers || []).map((r: any) => r.user.displayName),
           approval_status: {
-            approved_by: pr.reviewers.filter((r: any) => r.approved).map((r: any) => r.user.displayName),
-            changes_requested_by: pr.reviewers.filter((r: any) => r.status === 'NEEDS_WORK').map((r: any) => r.user.displayName),
-            pending: pr.reviewers.filter((r: any) => !r.approved && r.status !== 'NEEDS_WORK').map((r: any) => r.user.displayName)
+            approved_by: (pr.reviewers || []).filter((r: any) => r.approved).map((r: any) => r.user.displayName),
+            changes_requested_by: (pr.reviewers || []).filter((r: any) => r.status === 'NEEDS_WORK').map((r: any) => r.user.displayName),
+            pending: (pr.reviewers || []).filter((r: any) => !r.approved && r.status !== 'NEEDS_WORK').map((r: any) => r.user.displayName)
           },
           url: `${this.baseUrl}/projects/${workspace}/repos/${repository}/pull-requests/${pr.id}`
         }));
@@ -311,11 +311,11 @@ export class BranchHandlers {
           destination_branch: pr.destination.branch.name,
           author: pr.author.display_name,
           created_on: pr.created_on,
-          reviewers: pr.reviewers.map((r: any) => r.display_name),
+          reviewers: (pr.reviewers || []).map((r: any) => r.display_name),
           approval_status: {
-            approved_by: pr.participants.filter((p: any) => p.approved).map((p: any) => p.user.display_name),
+            approved_by: (pr.participants || []).filter((p: any) => p.approved).map((p: any) => p.user.display_name),
             changes_requested_by: [], // Cloud doesn't have explicit "changes requested" status
-            pending: pr.reviewers.filter((r: any) => !pr.participants.find((p: any) => p.user.account_id === r.account_id && p.approved))
+            pending: (pr.reviewers || []).filter((r: any) => !(pr.participants || []).find((p: any) => p.user.account_id === r.account_id && p.approved))
               .map((r: any) => r.display_name)
           },
           url: pr.links.html.href
@@ -342,7 +342,7 @@ export class BranchHandlers {
             id: pr.id,
             title: pr.title,
             merged_at: new Date(pr.updatedDate).toISOString(), // Using updated date as merge date
-            merged_by: pr.participants.find((p: any) => p.role === 'PARTICIPANT' && p.approved)?.user.displayName || 'Unknown'
+            merged_by: (pr.participants || []).find((p: any) => p.role === 'PARTICIPANT' && p.approved)?.user.displayName || 'Unknown'
           }));
         } else {
           // Bitbucket Cloud

--- a/src/handlers/pull-request-handlers.ts
+++ b/src/handlers/pull-request-handlers.ts
@@ -384,7 +384,7 @@ export class PullRequestHandlers {
           // User wants to update reviewers
           // Create a map of existing reviewers for preservation of approval status
           const existingReviewersMap = new Map(
-            currentPr.reviewers.map((r: any) => [r.user.name, r])
+            (currentPr.reviewers || []).map((r: any) => [r.user.name, r])
           );
           
           requestBody.reviewers = reviewers.map(username => {

--- a/src/handlers/pull-request-handlers.ts
+++ b/src/handlers/pull-request-handlers.ts
@@ -399,7 +399,7 @@ export class PullRequestHandlers {
           });
         } else {
           // No reviewers provided - preserve existing reviewers with their full data
-          requestBody.reviewers = currentPr.reviewers;
+          requestBody.reviewers = (currentPr.reviewers || []);
         }
       } else {
         // Bitbucket Cloud API

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -27,12 +27,12 @@ export function formatServerResponse(
     destination_branch: pr.toRef.displayId,
     source_commit: pr.fromRef.latestCommit,
     destination_commit: pr.toRef.latestCommit,
-    reviewers: pr.reviewers.map(r => ({
+    reviewers: (pr.reviewers || []).map(r => ({
       name: r.user.displayName,
       approved: r.approved,
       status: r.status,
     })),
-    participants: pr.participants.map(p => ({
+    participants: (pr.participants || []).map(p => ({
       name: p.user.displayName,
       role: p.role,
       approved: p.approved,
@@ -59,8 +59,8 @@ export function formatCloudResponse(pr: BitbucketCloudPullRequest): any {
     author: pr.author.display_name,
     source_branch: pr.source.branch.name,
     destination_branch: pr.destination.branch.name,
-    reviewers: pr.reviewers.map(r => r.display_name),
-    participants: pr.participants.map(p => ({
+    reviewers: (pr.reviewers || []).map(r => r.display_name),
+    participants: (pr.participants || []).map(p => ({
       name: p.user.display_name,
       role: p.role,
       approved: p.approved,
@@ -88,7 +88,7 @@ export function formatServerPRListItem(pr: BitbucketServerPullRequest, baseUrl?:
     destination_branch: pr.toRef.displayId,
     updated_on: new Date(pr.updatedDate).toLocaleString(),
     web_url: webUrl,
-    reviewers: pr.reviewers.map(r => ({ name: r.user.displayName, approved: r.approved })),
+    reviewers: (pr.reviewers || []).map(r => ({ name: r.user.displayName, approved: r.approved })),
   };
 }
 
@@ -103,7 +103,7 @@ export function formatCloudPRListItem(pr: BitbucketCloudPullRequest): any {
     destination_branch: pr.destination.branch.name,
     updated_on: new Date(pr.updated_on).toLocaleString(),
     web_url: pr.links.html.href,
-    reviewers: pr.reviewers.map(r => r.display_name),
+    reviewers: (pr.reviewers || []).map(r => r.display_name),
   };
 }
 
@@ -116,7 +116,7 @@ export function formatServerCommit(commit: BitbucketServerCommit): FormattedComm
       name: commit.author.name,
     },
     date: new Date(commit.authorTimestamp).toISOString(),
-    is_merge_commit: commit.parents.length > 1,
+    is_merge_commit: (commit.parents || []).length > 1,
   };
 }
 
@@ -132,7 +132,7 @@ export function formatCloudCommit(commit: BitbucketCloudCommit): FormattedCommit
       name: authorName,
     },
     date: commit.date,
-    is_merge_commit: commit.parents.length > 1,
+    is_merge_commit: (commit.parents || []).length > 1,
   };
 }
 


### PR DESCRIPTION
## Description

Adds `|| []` null-safety guards before `.map()`, `.filter()`, `.find()`, and `.length` calls on potentially-null array fields returned by the Bitbucket API.

The Bitbucket REST API can return `reviewers`, `participants`, and `parents` as `null` rather than empty arrays when absent. Without guards, this causes `TypeError` crashes.

Fixes #12

## Changes

### src/utils/formatters.ts (8 fixes)
- Guard `reviewers.map`, `participants.map` in formatServerResponse
- Guard `reviewers.map`, `participants.map` in formatCloudResponse
- Guard `reviewers.map` in formatServerPRListItem, formatCloudPRListItem
- Guard `parents.length` in formatServerCommit, formatCloudCommit

### src/handlers/branch-handlers.ts (8 fixes)
- Server PR section: 4 reviewer guards (.map + .filter ×3)
- Cloud PR section: reviewers.map, participants.filter, participants.find
- Server merged PR section: participants.find

### src/handlers/pull-request-handlers.ts (2 fixes)
- Guard `currentPr.reviewers.map(...)` (line 396) — prevents TypeError crash
- Guard `currentPr.reviewers` assignment to `requestBody.reviewers` (line 402) — prevents null leaking into request body

## Testing
- [x] `npm run build` compiles without errors
- [x] No unguarded `.map()`/`.filter()`/`.find()` remain in build output
- [x] Live-tested against Bitbucket Cloud API (list_repositories, get_branch, get_file_content, get_pull_request, get_commit_detail)