### PR TITLE
fix get_file_content

### DIFF
--- a/src/handlers/file-handlers.ts
+++ b/src/handlers/file-handlers.ts
@@ -191,7 +191,14 @@ export class FileHandlers {
         const branchOrDefault = branch || 'HEAD';
         const metaPath = `/repositories/${workspace}/${repository}/src/${branchOrDefault}/${file_path}`;
         
-        const metadataResponse = await this.apiClient.makeRequest<BitbucketCloudFileMetadata>('get', metaPath);
+        const metadataResponse = await this.apiClient.makeRequest<BitbucketCloudFileMetadata>(
+          'get',
+          metaPath,
+          undefined,
+          {
+            params: { format: 'meta' }
+          }
+        );
         
         fileMetadata = {
           size: metadataResponse.size,
@@ -219,10 +226,8 @@ export class FileHandlers {
           };
         }
 
-        // Follow the download link to get actual content
-        const downloadUrl = metadataResponse.links.download.href;
-        const downloadResponse = await this.apiClient.makeRequest<any>('get', downloadUrl, undefined, {
-          baseURL: '', // Use full URL
+        // Bitbucket Cloud returns raw file content from the same src path.
+        const downloadResponse = await this.apiClient.makeRequest<any>('get', metaPath, undefined, {
           responseType: 'text',
           headers: { 'Accept': 'text/plain' }
         });

--- a/src/types/bitbucket.ts
+++ b/src/types/bitbucket.ts
@@ -230,14 +230,16 @@ export interface BitbucketCloudFileMetadata {
   size: number;
   encoding?: string;
   mimetype?: string;
+  type?: string;
+  attributes?: string[];
   links: {
     self: {
       href: string;
     };
-    html: {
+    meta?: {
       href: string;
     };
-    download: {
+    html?: {
       href: string;
     };
   };


### PR DESCRIPTION
fixed get_file_content that is not working, gives this error

⚙  get_file_content
    {
      "workspace": "seaudi",
      "repository": "terraformai",
      "file_path": "README.md",
      "branch": "main",
      "full_content": true
    }
[2026-05-25 12:35:21] ERROR  Tool get_file_content failed: ERROR: MCP error -32603: Cannot read properties of undefined (reading 'download')

Root cause:
- In Bitbucket Cloud, GET /repositories/{workspace}/{repo}/src/{commit}/{path} returns raw file contents for files by default.
- The handler was treating that response as metadata and then reading metadataResponse.links.download.href, which does not exist for this endpoint.
- Bitbucket Cloud only returns file metadata when ?format=meta is requested.
Changes:
- src/handlers/file-handlers.ts:194
- Request Bitbucket Cloud file metadata with params: { format: 'meta' }.
- src/handlers/file-handlers.ts:229
- Stop dereferencing links.download.
- Fetch raw file contents directly from the same /src/... path with responseType: 'text'.
- src/types/bitbucket.ts:228
- Correct the Cloud metadata shape to match the API better.
- Removed the incorrect required links.download assumption and made links.meta/links.html optional.