### PR TITLE
fix: surface x-arequestid on auth/server errors for log correlation

### DIFF
--- a/src/utils/api-client.ts
+++ b/src/utils/api-client.ts
@@ -100,6 +100,12 @@ export class BitbucketApiClient {
     if (error.isAxiosError) {
       const { status, message } = error as ApiError;
 
+      // Surface Bitbucket's request id so operators can correlate an auth/server
+      // failure to the exact entry in the Bitbucket Data Center access logs. The
+      // header is present on every DC response but was otherwise dropped here.
+      const arequestid = (error as ApiError).originalError?.response?.headers?.['x-arequestid'];
+      const refSuffix = arequestid ? ` [bitbucket-ref: ${arequestid}]` : '';
+
       if (status === 404) {
         return {
           content: [
@@ -115,7 +121,7 @@ export class BitbucketApiClient {
           content: [
             {
               type: 'text',
-              text: `Authentication failed. Please check your ${this.isServer ? 'BITBUCKET_TOKEN' : 'BITBUCKET_USERNAME and BITBUCKET_APP_PASSWORD'}`,
+              text: `Authentication failed. Please check your ${this.isServer ? 'BITBUCKET_TOKEN' : 'BITBUCKET_USERNAME and BITBUCKET_APP_PASSWORD'}${refSuffix}`,
             },
           ],
           isError: true,
@@ -125,7 +131,7 @@ export class BitbucketApiClient {
           content: [
             {
               type: 'text',
-              text: `Permission denied: ${context}. Ensure your credentials have the necessary permissions.`,
+              text: `Permission denied: ${context}. Ensure your credentials have the necessary permissions.${refSuffix}`,
             },
           ],
           isError: true,
@@ -147,7 +153,7 @@ export class BitbucketApiClient {
         content: [
           {
             type: 'text',
-            text: `Bitbucket API error: ${message}`,
+            text: `Bitbucket API error: ${message}${refSuffix}`,
           },
         ],
         isError: true,


### PR DESCRIPTION
## What

Append Bitbucket's `x-arequestid` response header to the error text on **401**, **403**, and generic (5xx/other) failures, as ` [bitbucket-ref: <id>]`.

## Why

When a Bitbucket Data Center request fails with an auth or server error, the only reliable way for an operator to find the corresponding entry in the Bitbucket access logs is the `x-arequestid` header. Today `handleApiError()` returns a generic message and drops all response headers, so these failures are effectively untraceable — you can see *that* a 403 happened, but not *which* Bitbucket request it was.

The header is already available on the error object (`originalError.response.headers`) — it's read for `retry-after` on the 429 branch — so this just extends the same access to the auth/server branches.

## Change

`src/utils/api-client.ts` → `handleApiError()`:
- extract `x-arequestid` once at the top of the axios-error path;
- append ` [bitbucket-ref: <id>]` to the **401**, **403**, and **generic** error text when the header is present.

No change when the header is absent (e.g. non-DC responses) — the suffix is empty. **404** (not-found) is intentionally left untouched.

## Example

**Before:**
```
Permission denied: getting file content for 'x.ts' in PROJ/repo. Ensure your credentials have the necessary permissions.
```
**After:**
```
Permission denied: getting file content for 'x.ts' in PROJ/repo. Ensure your credentials have the necessary permissions. [bitbucket-ref: *ABC123x999x0]
```

## Testing

- `npm run build` passes (tsc clean).
- Verified against synthetic 401/403 axios errors: the ref is appended when the header is present and omitted when it's absent.

## Context

Surfaced during a production investigation where rare, transient Data Center-side 403s (a valid token intermittently getting "permission denied", self-healing on retry) were undiagnosable because the request id was lost at this layer. With this change, each such failure carries the `x-arequestid` needed to pivot straight to the Bitbucket access-log entry.
