### PR TITLE
fix(cloud): 11 Cloud-only bugs in file reads, filters, and PR writes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
-        "axios": "^1.10.0",
+        "axios": "^1.19.0",
         "form-data": "^4.0.4",
         "minimatch": "9.0.5",
         "tar-stream": "^3.2.0"
@@ -86,6 +86,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -107,13 +119,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -576,15 +590,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -595,16 +610,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -725,9 +740,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -748,6 +764,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/iconv-lite": {
@@ -945,9 +974,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "axios": "^1.10.0",
+    "axios": "^1.19.0",
     "form-data": "^4.0.4",
     "minimatch": "9.0.5",
     "tar-stream": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "rm -rf build && tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
     "dev": "tsc --watch",
     "start": "node build/index.js",
-    "test": "npm run build && node --test build/tests/",
+    "test": "npm run build && node --test build/tests/*.js",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/src/core/api-client.ts
+++ b/src/core/api-client.ts
@@ -40,6 +40,16 @@ export const CLOUD_MAX_PAGELEN = 100;
  */
 export const CLOUD_MAX_PAGELEN_PR_LIST = 50;
 
+/**
+ * Build a Cloud `q` name filter. Cloud has no `name` query parameter. The
+ * filtering language goes through `q`, as `name ~ "substring"`. The value is
+ * quoted, so a `"` or `\` inside it would otherwise terminate the expression
+ * early and produce a malformed query rather than a filtered result.
+ */
+export function cloudNameFilter(name: string): string {
+  return `name ~ "${name.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 /** Percent-encode a repo file path per segment (spaces, %, #, ? in filenames). */
 export function encodeRepoPath(path: string): string {
   return path.split('/').map(encodeURIComponent).join('/');

--- a/src/core/api-client.ts
+++ b/src/core/api-client.ts
@@ -24,6 +24,14 @@ import { InFlightCoalescer, TtlMemo } from './cache.js';
 
 type HttpMethod = 'get' | 'post' | 'put' | 'delete';
 
+/**
+ * Hard maximum Bitbucket Cloud accepts for `pagelen` on every paginated
+ * endpoint. Anything above it is a 400 "Invalid pagelen" — measured: 100 -> 200,
+ * 101 -> 400. Server/DC has no such cap, so Server-sized page sizes must be
+ * clamped before they reach a Cloud request.
+ */
+export const CLOUD_MAX_PAGELEN = 100;
+
 /** Percent-encode a repo file path per segment (spaces, %, #, ? in filenames). */
 export function encodeRepoPath(path: string): string {
   return path.split('/').map(encodeURIComponent).join('/');

--- a/src/core/api-client.ts
+++ b/src/core/api-client.ts
@@ -25,12 +25,20 @@ import { InFlightCoalescer, TtlMemo } from './cache.js';
 type HttpMethod = 'get' | 'post' | 'put' | 'delete';
 
 /**
- * Hard maximum Bitbucket Cloud accepts for `pagelen` on every paginated
- * endpoint. Anything above it is a 400 "Invalid pagelen" — measured: 100 -> 200,
- * 101 -> 400. Server/DC has no such cap, so Server-sized page sizes must be
- * clamped before they reach a Cloud request.
+ * Maximum `pagelen` Bitbucket Cloud accepts on most paginated endpoints.
+ * Above it the answer is 400 "Invalid pagelen": 100 works, 101 fails on /src,
+ * /commits and /refs/branches. Server/DC has no such cap,
+ * so Server-sized page sizes must be clamped before reaching a Cloud request.
  */
 export const CLOUD_MAX_PAGELEN = 100;
+
+/**
+ * The PR list endpoint caps lower than the rest, measured on
+ * /repositories/{ws}/{repo}/pullrequests: 50 -> 200, 51 -> 400 "Invalid
+ * pagelen". The ceiling is per-endpoint on Cloud, so it cannot be assumed
+ * uniform; pass the right one to clampPageSize.
+ */
+export const CLOUD_MAX_PAGELEN_PR_LIST = 50;
 
 /** Percent-encode a repo file path per segment (spaces, %, #, ? in filenames). */
 export function encodeRepoPath(path: string): string {
@@ -67,6 +75,23 @@ export class BitbucketApiClient {
       axiosConfig.auth = { username: auth.username, password: auth.appPassword };
     }
     this.axiosInstance = axios.create(axiosConfig);
+  }
+
+  /**
+   * Clamp a caller-supplied page size to what the target actually accepts.
+   * Cloud rejects anything above its ceiling with 400 "Invalid pagelen", and
+   * that ceiling is per-endpoint, 100 on most and 50 on the PR list, so pass
+   * `cloudMax` when it is not the usual 100. Server/DC has no such ceiling,
+   * so its limits pass through untouched.
+   *
+   * This deliberately clamps the LIMIT rather than the wire `pagelen`.
+   * Clamping only the wire value would leave has_more/next_start computed from
+   * the caller's original number, so a limit=200 request would return 100 rows
+   * while next_start advanced by 200, skipping the 100 in between.
+   * A short page is fine; a page that lies about where it ended is not.
+   */
+  clampPageSize(limit: number, cloudMax: number = CLOUD_MAX_PAGELEN): number {
+    return this.isServer ? limit : Math.min(limit, cloudMax);
   }
 
   getIsServer(): boolean {

--- a/src/handlers/branch-handlers.ts
+++ b/src/handlers/branch-handlers.ts
@@ -1,5 +1,5 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
-import { BitbucketApiClient, encodeRepoPath } from '../core/api-client.js';
+import { cloudNameFilter, BitbucketApiClient, encodeRepoPath } from '../core/api-client.js';
 import {
   isListBranchesArgs,
   isDeleteBranchArgs,
@@ -70,7 +70,7 @@ export class BranchHandlers {
           'get',
           `/repositories/${workspace}/${repository}/refs/branches`,
           undefined,
-          { params: { pagelen: limit, page: Math.floor(start / limit) + 1, ...(filter ? { q: `name ~ "${filter}"` } : {}) } }
+          { params: { pagelen: limit, page: Math.floor(start / limit) + 1, ...(filter ? { q: cloudNameFilter(filter) } : {}) } }
         );
         branches = (response.values || []).map((b: any) =>
           compactObject({ name: b.name, latest_commit: b.target?.hash?.slice(0, 12) })

--- a/src/handlers/branch-handlers.ts
+++ b/src/handlers/branch-handlers.ts
@@ -42,7 +42,7 @@ export class BranchHandlers {
       throw new McpError(ErrorCode.InvalidParams, 'Invalid arguments for list_branches');
     }
     const { workspace, repository, filter } = args;
-    const limit = args.limit ?? this.cfg.pagination.defaultListLimit;
+    const limit = this.apiClient.clampPageSize(args.limit ?? this.cfg.pagination.defaultListLimit);
     const start = args.start ?? 0;
 
     try {
@@ -253,7 +253,9 @@ export class BranchHandlers {
       workspace, repository, branch_name, since, until, author,
       include_merge_commits = true, search, include_build_status = false,
     } = args;
-    const limit = Math.min(args.limit ?? this.cfg.pagination.defaultListLimit, this.cfg.pagination.commitsPageLimit);
+    const limit = this.apiClient.clampPageSize(
+      Math.min(args.limit ?? this.cfg.pagination.defaultListLimit, this.cfg.pagination.commitsPageLimit)
+    );
     const start = args.start ?? 0;
 
     try {

--- a/src/handlers/branch-handlers.ts
+++ b/src/handlers/branch-handlers.ts
@@ -226,6 +226,30 @@ export class BranchHandlers {
           if (!ok) throw deleteError;
         }
       } else {
+        // Cloud's DELETE has no compare-and-swap, so expected_head has to be
+        // enforced here rather than passed along. Unenforced, a caller guarding
+        // against a branch that moved under them gets no guard and no warning:
+        // a deliberately wrong SHA still deletes the branch. This is
+        // check-then-delete, not an atomic CAS, so a push landing in the gap
+        // still slips through. It guards a stale expectation, not a race.
+        if (expected_head) {
+          const ref = await this.apiClient.makeRequest<any>(
+            'get',
+            `/repositories/${workspace}/${repository}/refs/branches/${encodeURIComponent(branch_name)}`
+          );
+          const head: string | undefined = ref?.target?.hash;
+          if (!head) return errorContent(`Branch '${branch_name}' not found`);
+          const expected = String(expected_head).toLowerCase();
+          const actual = head.toLowerCase();
+          // Accept an abbreviated SHA, but only as a real prefix of a sane length.
+          const agrees = expected.length >= 7 ? actual.startsWith(expected) : actual === expected;
+          if (!agrees) {
+            return errorContent(
+              `Refusing to delete '${branch_name}': its head is ${head}, but expected_head was ${expected_head}. ` +
+                `The branch moved. Re-read it and retry if the deletion is still what you want.`
+            );
+          }
+        }
         try {
           await this.apiClient.makeRequest<any>('delete', `/repositories/${workspace}/${repository}/refs/branches/${encodeURIComponent(branch_name)}`);
         } catch (deleteError: any) {

--- a/src/handlers/file-handlers.ts
+++ b/src/handlers/file-handlers.ts
@@ -60,7 +60,8 @@ export class FileHandlers {
         // is a 404 on Cloud, `/src/{ref}/` is the directory. dirPath being ''
         // leaves exactly that slash behind.
         let url: string | null = `/repositories/${workspace}/${repository}/src/${ref}/${dirPath}`;
-        let params: any | undefined = { pagelen: pagination.dirPageLimit };
+        // dirPageLimit defaults to a Server-sized 1000; Cloud 400s above 100.
+        let params: any | undefined = { pagelen: this.apiClient.clampPageSize(pagination.dirPageLimit) };
         for (let page = 0; page < pagination.browseMaxPages && url; page++) {
           const response: any = await this.apiClient.makeRequest<any>('get', url, undefined, params ? { params } : undefined);
           entries.push(

--- a/src/handlers/file-handlers.ts
+++ b/src/handlers/file-handlers.ts
@@ -55,8 +55,11 @@ export class FileHandlers {
           start = typeof children.nextPageStart === 'number' ? children.nextPageStart : start + (children.values?.length ?? 0);
         }
       } else {
-        const branchOrDefault = branch || 'HEAD';
-        let url: string | null = `/repositories/${workspace}/${repository}/src/${branchOrDefault}${dirPath ? `/${dirPath}` : ''}`;
+        const ref = await this.cloudSrcRef(workspace, repository, branch);
+        // The trailing slash is load-bearing for the ROOT listing: `/src/{ref}`
+        // is a 404 on Cloud, `/src/{ref}/` is the directory. dirPath being ''
+        // leaves exactly that slash behind.
+        let url: string | null = `/repositories/${workspace}/${repository}/src/${ref}/${dirPath}`;
         let params: any | undefined = { pagelen: pagination.dirPageLimit };
         for (let page = 0; page < pagination.browseMaxPages && url; page++) {
           const response: any = await this.apiClient.makeRequest<any>('get', url, undefined, params ? { params } : undefined);
@@ -140,6 +143,24 @@ export class FileHandlers {
     }
   }
 
+  /**
+   * Ref to use in a Cloud `/src/{ref}/{path}` read.
+   *
+   * Cloud resolves that URL by splitting on slashes, so a ref that contains one
+   * such as `feature/x` or `release/1.2`, swallows the path behind it. Requesting
+   * `/src/feature/x/a.py` resolves the ref `feature` and 404s, and encoding the
+   * slash does not help (`%2F` 404s identically). A commit SHA is the only ref
+   * form Cloud parses unambiguously, so slashed refs get resolved to one;
+   * resolveRef memoizes per (repo, ref) and passes 40-hex SHAs straight
+   * through. Slash-free refs and the default branch are left alone so the
+   * ordinary read stays a single request.
+   */
+  private async cloudSrcRef(workspace: string, repository: string, branch?: string): Promise<string> {
+    if (!branch) return 'HEAD';
+    if (!branch.includes('/')) return branch;
+    return await this.apiClient.resolveRef(workspace, repository, branch);
+  }
+
   private async rawContent(args: any): Promise<ToolResponse> {
     const { workspace, repository, file_path, branch, start_line, line_count } = args;
     let raw: string;
@@ -153,10 +174,10 @@ export class FileHandlers {
         { params, responseType: 'text', headers: { Accept: 'text/plain' } }
       );
     } else {
-      const branchOrDefault = branch || 'HEAD';
+      const ref = await this.cloudSrcRef(workspace, repository, branch);
       raw = await this.apiClient.makeRequest<string>(
         'get',
-        `/repositories/${workspace}/${repository}/src/${branchOrDefault}/${file_path}`,
+        `/repositories/${workspace}/${repository}/src/${ref}/${file_path}`,
         undefined,
         { responseType: 'text', headers: { Accept: 'text/plain' } }
       );

--- a/src/handlers/project-handlers.ts
+++ b/src/handlers/project-handlers.ts
@@ -1,5 +1,5 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
-import { BitbucketApiClient, CLOUD_MAX_PAGELEN } from '../core/api-client.js';
+import { BitbucketApiClient } from '../core/api-client.js';
 import { isListProjectsArgs, isListRepositoriesArgs } from '../tools/guards.js';
 import { compactObject, errorContent, jsonContent, serverPage } from '../formatting/respond.js';
 import type { ToolResponse } from '../types/index.js';
@@ -18,7 +18,7 @@ export class ProjectHandlers {
       throw new McpError(ErrorCode.InvalidParams, 'Invalid arguments for list_projects');
     }
     const { workspace, name, permission } = args;
-    const limit = args.limit ?? this.cfg.pagination.defaultListLimit;
+    const limit = this.apiClient.clampPageSize(args.limit ?? this.cfg.pagination.defaultListLimit);
     const start = args.start ?? 0;
 
     try {
@@ -45,7 +45,7 @@ export class ProjectHandlers {
       // token without workspace scope answers 404 for, so prefer passing one.
       const apiPath = workspace ? `/workspaces/${workspace}/projects` : '/workspaces';
       const response = await this.apiClient.makeRequest<any>('get', apiPath, undefined, {
-        params: { pagelen: Math.min(limit, CLOUD_MAX_PAGELEN), page: Math.floor(start / limit) + 1 },
+        params: { pagelen: limit, page: Math.floor(start / limit) + 1 },
       });
       const projects = (response.values || []).map((v: any) =>
         compactObject({
@@ -71,7 +71,7 @@ export class ProjectHandlers {
       throw new McpError(ErrorCode.InvalidParams, 'Invalid arguments for list_repositories');
     }
     const { workspace, name, permission } = args;
-    const limit = args.limit ?? this.cfg.pagination.defaultListLimit;
+    const limit = this.apiClient.clampPageSize(args.limit ?? this.cfg.pagination.defaultListLimit);
     const start = args.start ?? 0;
 
     try {

--- a/src/handlers/project-handlers.ts
+++ b/src/handlers/project-handlers.ts
@@ -1,5 +1,5 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
-import { BitbucketApiClient } from '../core/api-client.js';
+import { BitbucketApiClient, cloudNameFilter } from '../core/api-client.js';
 import { isListProjectsArgs, isListRepositoriesArgs } from '../tools/guards.js';
 import { compactObject, errorContent, jsonContent, serverPage } from '../formatting/respond.js';
 import type { ToolResponse } from '../types/index.js';
@@ -44,8 +44,15 @@ export class ProjectHandlers {
       // themselves, which an API
       // token without workspace scope answers 404 for, so prefer passing one.
       const apiPath = workspace ? `/workspaces/${workspace}/projects` : '/workspaces';
+      // `name` has to go through Cloud's `q` language; there is no name param.
+      // `permission` is a Server concept with Server-shaped values, so it is
+      // reported as ignored rather than silently dropped.
       const response = await this.apiClient.makeRequest<any>('get', apiPath, undefined, {
-        params: { pagelen: limit, page: Math.floor(start / limit) + 1 },
+        params: {
+          pagelen: limit,
+          page: Math.floor(start / limit) + 1,
+          ...(name ? { q: cloudNameFilter(name) } : {}),
+        },
       });
       const projects = (response.values || []).map((v: any) =>
         compactObject({
@@ -59,6 +66,7 @@ export class ProjectHandlers {
           projects,
           has_more: !!response.next || undefined,
           next_start: response.next ? start + limit : undefined,
+          note: permission ? 'permission filter ignored: Server/DC only' : undefined,
         })
       );
     } catch (error) {
@@ -102,7 +110,11 @@ export class ProjectHandlers {
         return errorContent('Bitbucket Cloud requires a workspace parameter to list repositories.');
       }
       const response = await this.apiClient.makeRequest<any>('get', `/repositories/${workspace}`, undefined, {
-        params: { pagelen: limit, page: Math.floor(start / limit) + 1 },
+        params: {
+          pagelen: limit,
+          page: Math.floor(start / limit) + 1,
+          ...(name ? { q: cloudNameFilter(name) } : {}),
+        },
       });
       const repositories = (response.values || []).map((r: any) =>
         compactObject({
@@ -117,6 +129,7 @@ export class ProjectHandlers {
           repositories,
           has_more: !!response.next || undefined,
           next_start: response.next ? start + limit : undefined,
+          note: permission ? 'permission filter ignored: Server/DC only' : undefined,
         })
       );
     } catch (error) {

--- a/src/handlers/project-handlers.ts
+++ b/src/handlers/project-handlers.ts
@@ -1,5 +1,5 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
-import { BitbucketApiClient } from '../core/api-client.js';
+import { BitbucketApiClient, CLOUD_MAX_PAGELEN } from '../core/api-client.js';
 import { isListProjectsArgs, isListRepositoriesArgs } from '../tools/guards.js';
 import { compactObject, errorContent, jsonContent, serverPage } from '../formatting/respond.js';
 import type { ToolResponse } from '../types/index.js';
@@ -17,7 +17,7 @@ export class ProjectHandlers {
     if (!isListProjectsArgs(args)) {
       throw new McpError(ErrorCode.InvalidParams, 'Invalid arguments for list_projects');
     }
-    const { name, permission } = args;
+    const { workspace, name, permission } = args;
     const limit = args.limit ?? this.cfg.pagination.defaultListLimit;
     const start = args.start ?? 0;
 
@@ -38,10 +38,22 @@ export class ProjectHandlers {
         );
       }
 
-      const response = await this.apiClient.makeRequest<any>('get', '/workspaces', undefined, {
-        params: { pagelen: limit, page: Math.floor(start / limit) + 1 },
+      // Cloud keeps projects under a workspace, so listing the CORE/URM/DEPL
+      // keys that repositories carry needs one: /workspaces/{ws}/projects.
+      // Without a workspace this falls back to listing the workspaces
+      // themselves, which an API
+      // token without workspace scope answers 404 for, so prefer passing one.
+      const apiPath = workspace ? `/workspaces/${workspace}/projects` : '/workspaces';
+      const response = await this.apiClient.makeRequest<any>('get', apiPath, undefined, {
+        params: { pagelen: Math.min(limit, CLOUD_MAX_PAGELEN), page: Math.floor(start / limit) + 1 },
       });
-      const projects = (response.values || []).map((w: any) => compactObject({ key: w.slug, name: w.name }));
+      const projects = (response.values || []).map((v: any) =>
+        compactObject({
+          key: workspace ? v.key : v.slug,
+          name: v.name,
+          description: workspace ? v.description || undefined : undefined,
+        })
+      );
       return jsonContent(
         compactObject({
           projects,

--- a/src/handlers/pull-request-handlers.ts
+++ b/src/handlers/pull-request-handlers.ts
@@ -1,6 +1,6 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { existsSync } from 'fs';
-import { BitbucketApiClient, CLOUD_MAX_PAGELEN, encodeRepoPath } from '../core/api-client.js';
+import { BitbucketApiClient, CLOUD_MAX_PAGELEN_PR_LIST, encodeRepoPath } from '../core/api-client.js';
 import {
   formatServerPullRequest,
   formatCloudPullRequest,
@@ -437,7 +437,10 @@ export class PullRequestHandlers {
       throw new McpError(ErrorCode.InvalidParams, 'Invalid arguments for list_pull_requests');
     }
     const { workspace, repository, state = 'OPEN', author, role } = args;
-    const limit = args.limit ?? this.cfg.pagination.defaultListLimit;
+    const limit = this.apiClient.clampPageSize(
+      args.limit ?? this.cfg.pagination.defaultListLimit,
+      CLOUD_MAX_PAGELEN_PR_LIST
+    );
     const start = args.start ?? 0;
 
     try {
@@ -952,7 +955,7 @@ export class PullRequestHandlers {
       throw new McpError(ErrorCode.InvalidParams, 'Invalid arguments for list_pr_commits');
     }
     const { workspace, repository, pull_request_id, include_build_status = false } = args;
-    const limit = args.limit ?? this.cfg.pagination.defaultListLimit;
+    const limit = this.apiClient.clampPageSize(args.limit ?? this.cfg.pagination.defaultListLimit);
     const start = args.start ?? 0;
 
     try {
@@ -974,9 +977,8 @@ export class PullRequestHandlers {
         // answers 400 "Invalid page" while `?pagelen=25` answers 200, so it
         // has to be walked by following `next` and slicing the window out.
         // start=0, the only offset a first call ever uses, costs one request.
-        // pagelen is capped at Cloud's hard maximum of 100.
         let url: string | null = `${this.cloudPrPath(workspace, repository, pull_request_id)}/commits`;
-        let reqParams: any | undefined = { pagelen: Math.min(limit, CLOUD_MAX_PAGELEN) };
+        let reqParams: any | undefined = { pagelen: limit };
         const collected: any[] = [];
         for (let page = 0; page < this.cfg.pagination.commitsFilterMaxPages && url; page++) {
           const response: any = await this.apiClient.makeRequest<any>(

--- a/src/handlers/pull-request-handlers.ts
+++ b/src/handlers/pull-request-handlers.ts
@@ -1,6 +1,6 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { existsSync } from 'fs';
-import { BitbucketApiClient, encodeRepoPath } from '../core/api-client.js';
+import { BitbucketApiClient, CLOUD_MAX_PAGELEN, encodeRepoPath } from '../core/api-client.js';
 import {
   formatServerPullRequest,
   formatCloudPullRequest,
@@ -970,14 +970,30 @@ export class PullRequestHandlers {
         commits = (response.values || []).map(formatServerCommit);
         ({ hasMore, nextStart } = serverPage(response));
       } else {
-        const response = await this.apiClient.makeRequest<any>(
-          'get',
-          `${this.cloudPrPath(workspace, repository, pull_request_id)}/commits`,
-          undefined,
-          { params: { pagelen: limit, page: Math.floor(start / limit) + 1 } }
-        );
-        commits = (response.values || []).map(formatCloudCommit);
-        hasMore = !!response.next;
+        // Cloud rejects `page` outright on this endpoint. `?pagelen=25&page=1`
+        // answers 400 "Invalid page" while `?pagelen=25` answers 200, so it
+        // has to be walked by following `next` and slicing the window out.
+        // start=0, the only offset a first call ever uses, costs one request.
+        // pagelen is capped at Cloud's hard maximum of 100.
+        let url: string | null = `${this.cloudPrPath(workspace, repository, pull_request_id)}/commits`;
+        let reqParams: any | undefined = { pagelen: Math.min(limit, CLOUD_MAX_PAGELEN) };
+        const collected: any[] = [];
+        for (let page = 0; page < this.cfg.pagination.commitsFilterMaxPages && url; page++) {
+          const response: any = await this.apiClient.makeRequest<any>(
+            'get',
+            url,
+            undefined,
+            reqParams ? { params: reqParams } : undefined
+          );
+          collected.push(...(response.values || []));
+          url = response.next || null; // absolute URL; axios overrides baseURL
+          reqParams = undefined;
+          if (collected.length >= start + limit) break;
+        }
+        commits = collected.slice(start, start + limit).map(formatCloudCommit);
+        // More exists if we over-fetched past the window, or pages remain
+        // (including the page-cap case, where url is still set).
+        hasMore = collected.length > start + limit || url !== null;
         nextStart = hasMore ? start + limit : undefined;
       }
 

--- a/src/handlers/pull-request-handlers.ts
+++ b/src/handlers/pull-request-handlers.ts
@@ -794,6 +794,16 @@ export class PullRequestHandlers {
       code_snippet, search_context, match_strategy = 'strict', severity, attachments,
     } = args;
 
+    // code_snippet can only be resolved within a known file's diff. Without
+    // file_path the block is skipped, the comment is created with no anchor, and
+    // the call reports success: you asked to annotate a line and got a
+    // PR-level comment instead.
+    if (code_snippet && !line_number && !file_path) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'code_snippet needs file_path to resolve against that file\'s diff. Pass file_path, or pass line_number directly.'
+      );
+    }
     if (code_snippet && !line_number && file_path) {
       const resolved = await this.resolveLineFromCode(
         workspace, repository, pull_request_id, file_path, code_snippet, search_context, match_strategy
@@ -1066,17 +1076,30 @@ export class PullRequestHandlers {
       if (matches.length === 0) {
         throw new McpError(ErrorCode.InvalidParams, `Code snippet not found in ${filePath}`);
       }
-      if (matches.length === 1 || matchStrategy === 'best') {
-        const best = matches.sort((a, b) => b.confidence - a.confidence)[0];
+
+      // search_context is what the ambiguity error below tells callers to add,
+      // so it has to actually narrow the field. It only ever fed the confidence
+      // score while the ambiguity check counted raw matches, which meant taking
+      // the error's advice changed nothing. Keep the best-scoring candidates and
+      // accept a unique winner; anything still tied stays ambiguous.
+      let candidates = matches;
+      if (searchContext && candidates.length > 1) {
+        const top = Math.max(...candidates.map(m => m.confidence));
+        const leaders = candidates.filter(m => Math.abs(m.confidence - top) < 1e-9);
+        if (leaders.length === 1) candidates = leaders;
+      }
+
+      if (candidates.length === 1 || matchStrategy === 'best') {
+        const best = candidates.sort((a, b) => b.confidence - a.confidence)[0];
         return { line_number: best.line_number, line_type: best.line_type };
       }
 
-      const listed = matches.slice(0, this.cfg.output.snippetMatchListMax);
+      const listed = candidates.slice(0, this.cfg.output.snippetMatchListMax);
       throw new McpError(
         ErrorCode.InvalidParams,
-        `Code snippet matches ${matches.length} locations in ${filePath}: ` +
+        `Code snippet matches ${candidates.length} locations in ${filePath}: ` +
           listed.map(m => `line ${m.line_number} (${m.line_type})`).join(', ') +
-          (matches.length > listed.length ? ` …and ${matches.length - listed.length} more.` : '') +
+          (candidates.length > listed.length ? ` …and ${candidates.length - listed.length} more.` : '') +
           ` Add search_context, use match_strategy:"best", or pass line_number directly.`
       );
     } catch (error) {

--- a/src/handlers/pull-request-handlers.ts
+++ b/src/handlers/pull-request-handlers.ts
@@ -754,8 +754,11 @@ export class PullRequestHandlers {
           typeof args.version === 'number'
         );
       } else {
-        // Cloud decline takes no version — no read needed.
-        await this.apiClient.makeRequest('post', `${this.cloudPrPath(workspace, repository, pull_request_id)}/decline`);
+        // Cloud decline takes no version, so no read is needed. It does, however,
+        // insist on a body: a POST with none answers 400. An empty object is
+        // enough, and is what makes axios send a Content-Type/Content-Length
+        // at all.
+        await this.apiClient.makeRequest('post', `${this.cloudPrPath(workspace, repository, pull_request_id)}/decline`, {});
       }
 
       let commentNote = '';

--- a/src/handlers/review-handlers.ts
+++ b/src/handlers/review-handlers.ts
@@ -113,9 +113,10 @@ export class ReviewHandlers {
       } else {
         const base = `/repositories/${workspace}/${repository}/pullrequests/${pull_request_id}`;
         if (status === 'APPROVED') {
-          await this.apiClient.makeRequest<any>('post', `${base}/approve`);
+          // Cloud 400s a bodyless POST here, same as /decline. Send {}.
+          await this.apiClient.makeRequest<any>('post', `${base}/approve`, {});
         } else if (status === 'NEEDS_WORK') {
-          await this.apiClient.makeRequest<any>('post', `${base}/request-changes`);
+          await this.apiClient.makeRequest<any>('post', `${base}/request-changes`, {});
         } else {
           // UNAPPROVED: clear both possible prior states. Only a 404
           // ("nothing to clear") is expected — anything else is a real error.

--- a/src/tests/core.test.ts
+++ b/src/tests/core.test.ts
@@ -7,6 +7,7 @@ import { buildQueryFromClauses, quoteIfNeeded } from '../core/query-budget.js';
 import { LineScanner } from '../core/snapshot.js';
 import { truncateMarked, compactObject, isoDate, isCommitRev, toEpochMillis, serverPage } from '../formatting/respond.js';
 import { isPosInt, optNonNegInt } from '../tools/guards.js';
+import { cloudNameFilter, CLOUD_MAX_PAGELEN, CLOUD_MAX_PAGELEN_PR_LIST } from '../core/api-client.js';
 
 // ── throttle ─────────────────────────────────────────────────────────────────
 
@@ -227,4 +228,23 @@ test('truncateMarked marks, compactObject drops empties, isoDate normalizes', ()
   assert.deepEqual(compactObject({ a: 1, b: undefined, c: null, d: '' }), { a: 1 });
   assert.equal(isoDate(0), '1970-01-01T00:00:00.000Z');
   assert.equal(isoDate('not-a-date'), undefined);
+});
+
+// ── Cloud query and paging limits ────────────────────────────────────────────
+
+test('cloudNameFilter: builds a q clause and escapes the value', () => {
+  assert.equal(cloudNameFilter('widget'), 'name ~ "widget"');
+  // A quote would otherwise close the expression early and malform the query.
+  assert.equal(cloudNameFilter('say "hi"'), 'name ~ "say \\"hi\\""');
+  // Backslashes escape first, so the quote escape cannot be neutralised.
+  assert.equal(cloudNameFilter('back\\slash'), 'name ~ "back\\\\slash"');
+  assert.equal(cloudNameFilter(''), 'name ~ ""');
+});
+
+test('cloud pagelen ceilings: the PR list is lower than the rest', () => {
+  // Measured against api.bitbucket.org: /src, /commits and /refs/branches
+  // accept 100 and reject 101, while /pullrequests accepts 50 and rejects 51.
+  assert.equal(CLOUD_MAX_PAGELEN, 100);
+  assert.equal(CLOUD_MAX_PAGELEN_PR_LIST, 50);
+  assert.ok(CLOUD_MAX_PAGELEN_PR_LIST < CLOUD_MAX_PAGELEN);
 });

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -367,7 +367,7 @@ export const toolDefinitions: ToolDefinition[] = [
         workspace: W,
         repository: R,
         branch_name: { type: 'string' },
-        expected_head: { type: 'string', description: 'Known head SHA (compare-and-swap)' },
+        expected_head: { type: 'string', description: 'Refuse the delete unless the head matches this SHA (abbreviations allowed). Atomic compare-and-swap on Server; checked immediately before deleting on Cloud.' },
       },
       required: ['workspace', 'repository', 'branch_name'],
     },

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -519,12 +519,13 @@ export const toolDefinitions: ToolDefinition[] = [
   // ── Discovery ──────────────────────────────────────────────────────────────
   {
     name: 'list_projects',
-    description: 'List accessible projects/workspaces.',
+    description: 'List projects. On Cloud pass `workspace` to list its projects (the keys repositories carry); omitting it lists workspaces instead. On Server lists accessible projects.',
     group: 'discovery',
     availability: 'both',
     inputSchema: {
       type: 'object',
       properties: {
+        workspace: { type: 'string', description: 'Workspace slug. Lists projects inside it (Cloud)' },
         name: { type: 'string', description: 'Name filter' },
         permission: { type: 'string', description: 'e.g. PROJECT_READ' },
         limit: LIMIT,

--- a/src/tools/guards.ts
+++ b/src/tools/guards.ts
@@ -222,9 +222,10 @@ export function isGetFileBlameArgs(a: any): a is {
 // ── Discovery ────────────────────────────────────────────────────────────────
 
 export function isListProjectsArgs(a: any): a is {
-  name?: string; permission?: string; limit?: number; start?: number;
+  workspace?: string; name?: string; permission?: string; limit?: number; start?: number;
 } {
-  return isObj(a) && optStr(a.name) && optStr(a.permission) && optPosInt(a.limit) && optNonNegInt(a.start);
+  return isObj(a) && optStr(a.workspace) && optStr(a.name) && optStr(a.permission) &&
+    optPosInt(a.limit) && optNonNegInt(a.start);
 }
 
 export function isListRepositoriesArgs(a: any): a is {


### PR DESCRIPTION
Great work on this MCP. I gave it a run against our Bitbucket Cloud instance and hit a few bugs, so this PR fixes the ones I could pin down.

Most of them fail quietly. They return success, or an error that points at the wrong cause, which is probably why they have survived. I checked each one against `api.bitbucket.org` rather than guessing, and the evidence column has the request and response so you can confirm without re-testing.

## The fixes

| Fix | Cause | Evidence |
|---|---|---|
| File reads on slashed branches | Cloud splits `/src/{ref}/{path}` on slashes, so a ref containing one swallows the path. It reported `File not found`, so any read on a `feature/*` or `release/*` branch gave a confident wrong answer. Encoding does not help. | `/src/master/f` 200, `/src/feature/x/f` 404, `/src/<sha>/f` 200 |
| Root directory listing | The URL was built without a trailing slash. | `/src/master` 404, `/src/master/` 200 |
| `list_pr_commits` on Cloud | It sends `page`, which this endpoint rejects, so the tool never worked on Cloud. | `?pagelen=25&page=1` 400 `Invalid page`, `?pagelen=25` 200 |
| `list_projects` returned workspaces | On Cloud it called `/workspaces`, which lists workspaces rather than the project keys repos carry. | now takes `workspace`, reads `/workspaces/{ws}/projects` |
| `limit` above the ceiling | The caller's `limit` went straight to the wire, and Cloud's ceiling is per endpoint. | `/src`, `/commits`, `/refs/branches` take 100 and reject 101. `/pullrequests` takes 50 and rejects 51 |
| `decline_pull_request` and `set_review_status` | Cloud rejects these POSTs when axios sends no body, so both were broken on every call. `merge_pull_request` always sends one, which is what made the difference visible. | `POST /decline` bodyless 400, with `{}` 204 |
| `name` filter was ignored | Cloud has no `name` parameter. Filtering goes through `q`, and neither handler sent anything, so a filtered list returned everything. `permission` has no Cloud equivalent at all, and Cloud ignores unknown query params, so it was dropped just as quietly. It is now reported as ignored. | a `name`-filtered list returned repositories that do not match the filter |
| `search_context` had no effect | It fed the confidence score, but the ambiguity check counted raw matches and never read the scores. The error told you to add context, and adding it changed nothing. | ambiguous snippet stayed ambiguous with any context |
| `code_snippet` without `file_path` | Resolution is guarded on `file_path`, so the block was skipped and the comment posted with no anchor, returning success. | response carried no `file_path` or `line_number` |
| `expected_head` on `delete_branch` | It was passed nowhere on Cloud, so the compare-and-swap guard guarded nothing. | deleting with `expected_head=000...0` succeeded |
| `get_pull_request_diff` returned `Not found` | axios 1.10.0 does not follow Cloud's PR-diff 302. | floor raised to 1.19.0 |

## Two changes that are not bug fixes

I left both in because the PR needs them, but happy to pull either out.

The **axios floor** is the fix for the last row, not housekeeping. The lockfile pinned 1.10.0, which is why the diff bug only shows up in a lockfile-honouring build.

The **`npm test` script** could not run at all: `node --test build/tests/` resolves the directory as a module and dies with `MODULE_NOT_FOUND` before any test executes. Same on a clean checkout of `main`. Globbing the files fixes it, and without it the two tests I added here never run for you. Suite is 30 pass, 0 fail.

## Related issues

This closes the second half of #25. @siavashkiani-tech diagnosed both bugs there, and landed on the same shape I used for `list_projects`: an optional `workspace` argument, matching `list_repositories`. They also offered to send a PR for it, so if you would rather take theirs, please do. I did not see one open, and I had the fix in hand, but the credit for the diagnosis is theirs.

The first half of #25, `list_pull_requests` throwing on missing `reviewers`, is #23 rather than this PR.

I also had a look at the other open PRs so this does not collide with anyone:

- #26 and #24 both merge cleanly on top of this branch. I checked with a trial merge.
- #21 touches only `package.json` and the lockfile, which I also touch, so it is a small textual conflict either way round.
- #15, #10, #11 and #2 predate the v3 rewrite. They patch code paths that no longer exist, such as `metadataResponse.links.download.href` and `src/utils/api-client.ts`, which is why GitHub already reports them as conflicting. Worth noting the file-content bug behind #15 and #10 looks fixed by the rewrite itself, since v3 reads the raw file directly instead of following a download link.

## Scope

Cloud only. No Server/DC behaviour changes: every fix sits in a Cloud branch, and the one new helper (`clampPageSize`) passes Server limits through untouched.

The `reviewers` and `commit.parents` null guards from #22 are not here, since they are already in #23.

---

Next, I would also like to add **repository management tools for Bitbucket Cloud**: branch restrictions, branching model, repository settings, default reviewers, permissions, pipelines config and variables, webhooks, deploy keys, and environments. I already have a working implementation, with the writes behind an opt-in flag and a `dry_run` on every mutating tool, since these can change branch permissions.

Would you want that upstream? Happy to open it as a separate PR, or leave it in my fork if it is outside what you want this server to cover. Either way, no rush on my end.

Also glad to split this PR into smaller ones if that is easier to review.





